### PR TITLE
Develop

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -75,7 +75,9 @@ struct psz_context {
   // codec config
   uint32_t codecs_in_use{0b01};
   int vle_sublen{512}, vle_pardeg{-1};
+  INTERPOLATION_PARAMS intp_param;
 };
+
 typedef struct psz_context psz_context;
 typedef psz_context pszctx;
 

--- a/include/cusz/type.h
+++ b/include/cusz/type.h
@@ -200,6 +200,22 @@ typedef u1* pszout;
 // used for bridging some compressor internal buffer
 typedef pszout* ptr_pszout;
 
+struct INTERPOLATION_PARAMS {
+    // 
+    double alpha{1.75};
+    double beta{3.0};
+    
+    //
+    bool interpolators[3];
+    
+    //
+    bool reverse[3];
+
+    //
+    INTERPOLATION_PARAMS() : interpolators{true, true, true}, reverse{false, false, false} {};
+};
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/header.h
+++ b/include/header.h
@@ -50,7 +50,9 @@ typedef struct alignas(128) psz_header {
   // uint32_t byte_uncomp : 4;   // T; 1, 2, 4, 8
   // uint32_t byte_errctrl : 3;  // 1, 2, 4
   // uint32_t byte_meta : 4;     // 4, 8
-
+  
+  
+  INTERPOLATION_PARAMS intp_param;
 } psz_header;
 typedef psz_header pszheader;
 

--- a/include/kernel/spline.hh
+++ b/include/kernel/spline.hh
@@ -20,11 +20,11 @@
 template <typename T, typename E, typename FP = T>
 int spline_construct(
     pszmem_cxx<T>* data, pszmem_cxx<T>* anchor, pszmem_cxx<E>* errctrl,
-    void* _outlier, double eb, uint32_t radius, float* time, void* stream);
+    void* _outlier, double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream);
 
 template <typename T, typename E, typename FP = T>
 int spline_reconstruct(
     pszmem_cxx<T>* anchor, pszmem_cxx<E>* errctrl, pszmem_cxx<T>* xdata,
-    double eb, uint32_t radius, float* time, void* stream);
+    double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream);
 
 #endif /* AA9BE6AD_ECA4_4267_A97F_B12C25A2B0C1 */

--- a/include/utils/config.hh
+++ b/include/utils/config.hh
@@ -78,7 +78,6 @@ struct psz_helper {
     static std::pair<std::string, std::string> separate_kv(std::string& s)
     {
         std::string delimiter = "=";
-
         if (s.find(delimiter) == std::string::npos)
             throw std::runtime_error("\e[1mnot a correct key-value syntax, must be \"opt=value\"\e[0m");
 
@@ -90,10 +89,14 @@ struct psz_helper {
 
     static void parse_strlist_as_kv(const char* in_str, map_t& kv_list)
     {
-        ss_t ss(in_str);
+        ss_t ss;
+        std::ifstream config_file(in_str);
+        if(config_file)
+            ss << config_file.rdbuf();
+        config_file.close();
         while (ss.good()) {
             std::string tmp;
-            std::getline(ss, tmp, ',');
+            std::getline(ss, tmp);
             kv_list.insert(separate_kv(tmp));
         }
     }

--- a/src/cli_psz.cc
+++ b/src/cli_psz.cc
@@ -11,7 +11,7 @@ int main(int argc, char** argv)
     CPU_QUERY;
     GPU_QUERY;
   }
-
+  
   cusz::CLI<float> cusz_cli;
   cusz_cli.dispatch(ctx);
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -172,6 +172,30 @@ void pszctx_parse_control_string(
     else if (optmatch({"gpuverify"}) and is_enabled(v)) {
       ctx->use_gpu_verify = true;
     }
+    else if (optmatch({"alpha"})) {
+      ctx->intp_param.alpha = psz_helper::str2fp(v);
+    }
+    else if (optmatch({"beta"})) {
+      ctx->intp_param.beta = psz_helper::str2fp(v);
+    }
+    else if (optmatch({"intp_0"})) {
+      ctx->intp_param.interpolators[0] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"intp_1"})) {
+      ctx->intp_param.interpolators[1] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"intp_2"})) {
+      ctx->intp_param.interpolators[2] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"rev_0"})) {
+      ctx->intp_param.reverse[0] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"rev_1"})) {
+      ctx->intp_param.reverse[1] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"rev_2"})) {
+      ctx->intp_param.reverse[2] = psz_helper::str2int(v);
+    }
   }
 }
 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -37,10 +37,9 @@ constexpr int DEFAULT_BLOCK_SIZE = 384;
 template <typename T, typename E, typename FP>
 int spline_construct(
     pszmem_cxx<T>* data, pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl,
-    void* _outlier, double eb, uint32_t radius, float* time, void* stream)
+    void* _outlier, double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream)
 {
   constexpr auto BLOCK = 8;
-
   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
 
   auto ebx2 = eb * 2;
@@ -63,7 +62,7 @@ int spline_construct(
           ectrl->dptr(), ectrl->template len3<dim3>(),
           ectrl->template st3<dim3>(),  //
           anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
-          ot->num(), eb_r, ebx2, radius);
+          ot->num(), eb_r, ebx2, radius, intp_param);
 
   STOP_GPUEVENT_RECORDING(stream);
   CHECK_GPU(GpuStreamSync(stream));
@@ -76,7 +75,7 @@ int spline_construct(
 template <typename T, typename E, typename FP>
 int spline_reconstruct(
     pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl, pszmem_cxx<T>* xdata,
-    double eb, uint32_t radius, float* time, void* stream)
+    double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream)
 {
   constexpr auto BLOCK = 8;
 
@@ -100,7 +99,7 @@ int spline_reconstruct(
        anchor->template st3<dim3>(),  //
        xdata->dptr(), xdata->template len3<dim3>(),
        xdata->template st3<dim3>(),  //
-       eb_r, ebx2, radius);
+       eb_r, ebx2, radius, intp_param);
 
   STOP_GPUEVENT_RECORDING(stream);
   CHECK_GPU(GpuStreamSync(stream));
@@ -113,10 +112,10 @@ int spline_reconstruct(
 #define INIT(T, E)                                                            \
   template int spline_construct<T, E>(                                        \
       pszmem_cxx<T> * data, pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl,    \
-      void* _outlier, double eb, uint32_t radius, float* time, void* stream); \
+      void* _outlier, double eb, uint32_t radius, struct INTERPOLATION_PARAMS intp_param, float* time, void* stream); \
   template int spline_reconstruct<T, E>(                                      \
       pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl, pszmem_cxx<T> * xdata,   \
-      double eb, uint32_t radius, float* time, void* stream);
+      double eb, uint32_t radius, struct INTERPOLATION_PARAMS intp_param, float* time, void* stream);
 
 INIT(f4, u1)
 INIT(f4, u2)

--- a/src/pipeline/compressor.inl
+++ b/src/pipeline/compressor.inl
@@ -89,7 +89,8 @@ COR::compress_predict(pszctx* ctx, T* in, void* stream)
   auto const eb = ctx->eb;
   auto const radius = ctx->radius;
   auto const pardeg = ctx->vle_pardeg;
-
+  const auto booklen = radius * 2;
+  INTERPOLATION_PARAMS intp_param = ctx->intp_param;
   // [psz::note::TODO] compat layer or explicit macro
 #if defined(PSZ_USE_CUDA) || defined(PSZ_USE_HIP)
   auto len3 = dim3(ctx->x, ctx->y, ctx->z);
@@ -103,7 +104,7 @@ COR::compress_predict(pszctx* ctx, T* in, void* stream)
 #ifdef PSZ_USE_CUDA
       mem->od->dptr(in);
       spline_construct(
-          mem->od, mem->ac, mem->e, (void*)mem->compact, eb, radius,
+          mem->od, mem->ac, mem->e, (void*)mem->compact, eb, radius, intp_param,
           &time_pred, stream);
 #else
       throw runtime_error(
@@ -349,7 +350,7 @@ COR::decompress_predict(
 
   const auto eb = header->eb;
   const auto radius = header->radius;
-
+  INTERPOLATION_PARAMS intp_param = header->intp_param;
   if (in and ext_anchor)
     throw std::runtime_error(
         "[psz::error] One of external in and ext_anchor must be null.");
@@ -377,7 +378,7 @@ COR::decompress_predict(
     // [psz::TODO] throw exception
 
     spline_reconstruct(
-        &anchor, mem->e, mem->xd, eb, radius, &time_pred, stream);
+        &anchor, mem->e, mem->xd, eb, radius, intp_param, &time_pred, stream);
 #else
     throw runtime_error(
         "[psz::error] spline_reconstruct not implemented other than CUDA.");

--- a/src/pipeline/compressor.inl
+++ b/src/pipeline/compressor.inl
@@ -97,10 +97,6 @@ COR::compress_predict(pszctx* ctx, T* in, void* stream)
 #elif defined(PSZ_USE_1API)
   auto len3 = sycl::range<3>(ctx->z, ctx->y, ctx->x);
 #endif
-  printf("alpha = %f, beta = %f, interpolators = {%d, %d, %d}, reverse = {%d, %d, %d}\n", \
-         ctx->intp_param.alpha,ctx->intp_param.beta, ctx->intp_param.interpolators[0],
-         ctx->intp_param.interpolators[1], ctx->intp_param.interpolators[2],
-         ctx->intp_param.reverse[0], ctx->intp_param.reverse[1], ctx->intp_param.reverse[2]);
   /* prediction-quantization with compaction */
   {
     if (spline_in_use()) {

--- a/src/pipeline/compressor.inl
+++ b/src/pipeline/compressor.inl
@@ -97,7 +97,10 @@ COR::compress_predict(pszctx* ctx, T* in, void* stream)
 #elif defined(PSZ_USE_1API)
   auto len3 = sycl::range<3>(ctx->z, ctx->y, ctx->x);
 #endif
-
+  printf("alpha = %f, beta = %f, interpolators = {%d, %d, %d}, reverse = {%d, %d, %d}\n", \
+         ctx->intp_param.alpha,ctx->intp_param.beta, ctx->intp_param.interpolators[0],
+         ctx->intp_param.interpolators[1], ctx->intp_param.interpolators[2],
+         ctx->intp_param.reverse[0], ctx->intp_param.reverse[1], ctx->intp_param.reverse[2]);
   /* prediction-quantization with compaction */
   {
     if (spline_in_use()) {


### PR DESCRIPTION
@jtian0 @meso272 Hi Jiannan and Jinyang, I add the interpolation configuration into the up-to-date develop branch:
- An `INTERPOLATION_PARAMS` struct inside `include/cusz/type.h`. The struct `INTERPOLATION_PARAMS` contains 4 parameters: `double alpha` = 1.75, `double beta` = 3.0, `bool interpolators[3]` = {true, true, true}, and `bool reverse[3]` = {false, false, false}. 
- An object of the struct `INTERPOLATION_PARAMS` is added to struct `psz_context` and `psz_header`, respectively.
- An argument `INTERPOLATION_PARAMS intp_param` is added to function `spline_construct()`,  `spline_reconstruct()`, `c_spline3d_infprecis_32x8x8data()`, `x_spline3d_infprecis_32x8x8data()`, and `spline3d_layout2_interpolate()`.
- Modify the logic of `--config`: --config takes a configuration file name and read the config file line by line. Each line in the config file follows the pattern of `key=value`.